### PR TITLE
Add iOS web clip compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,15 @@
     <meta name="twitter:title" content="WebVM" />
     <meta name="twitter:description" content="Welcome to WebVM - a server-less virtual Linux environment running fully client-side in HTML5/WebAssembly."
     <meta name="twitter:image" content="https://webvm.io/assets/webvm.jpeg" />
+    
+    <!-- Apple iOS web clip compatibility tags -->
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="application-name" content="WebVM" />
+    <meta name="apple-mobile-web-app-title" content="WebVM" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+	 
 
     <link rel="shortcut icon" href="/favicon.ico">
     <link rel="preconnect" href="https://fonts.gstatic.com">


### PR DESCRIPTION
This will make it so iOS Safari’s “Add to Home Screen” feature will make the site fullscreen and independent of the Safari application.