### PR TITLE
Serviceworker small fix & clarification.

### DIFF
--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -55,7 +55,11 @@ async function doRegister() {
 		// f.e on first access.
 		registration.addEventListener("updatefound", () => {
 			console.log("Reloading the page to transfer control to the Service Worker.");
-			window.location.reload();
+			try {
+				window.location.reload();
+			} catch (err) {
+				console.log("Service Worker failed reloading the page. ERROR:" + err);
+			};
 		});
 		// If the registration is active, but it's not controlling the page, reload the page to have it take control
 		if (registration.active && !navigator.serviceWorker.controller) {

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -61,7 +61,8 @@ async function doRegister() {
 				console.log("Service Worker failed reloading the page. ERROR:" + err);
 			};
 		});
-		// If the registration is active, but it's not controlling the page, reload the page to have it take control
+		// When the registration is active, but it's not controlling the page, we reload the page to have it take control.
+		// This f.e occurs when you hard-reload (shift + refresh). https://www.w3.org/TR/service-workers/#navigator-service-worker-controller
 		if (registration.active && !navigator.serviceWorker.controller) {
 			console.log("Reloading the page to transfer control to the Service Worker.");
 			try {


### PR DESCRIPTION
### ***Changelog***
---
* Added a comment for additional clarification for why we have the `if (registration.active && !navigator.serviceWorker.controller)` reload block.
*  Put the unguarded reload in doRegister into a try/catch block.
