### PR TITLE
Workflow: Guard clause has its own job, error handling for poor pages configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,62 @@ on:
 
 jobs:
 
+  guard_clause:
+      runs-on: ubuntu-latest
+  
+      env:
+        GH_TOKEN: ${{ github.token }} # As required by the GitHub-CLI  
+
+      permissions:
+        actions: 'write' # Required in order to terminate the workflow run.
+  
+      steps:
+        - uses: actions/checkout@v3
+        # Guard clause that cancels the workflow in case of an invalid DOCKERFILE_PATH and/or incorrectly configured Github Pages. 
+        # The main reason for choosing this workaround for aborting the workflow is the fact that it does not display the workflow as successful, which can set false expectations.
+        - name: DOCKERFILE_PATH.
+          shell: bash
+          run: |
+            # We check whether the Dockerfile_path is valid. 
+            if [ ! -f ${{ github.event.inputs.DOCKERFILE_PATH }} ]; then
+                echo "::error title=Invalid Dockerfile path::No file found at ${{ github.event.inputs.DOCKERFILE_PATH }}"
+                echo "terminate=true" >> $GITHUB_ENV
+            fi
+
+        - name: Github Pages config guard clause
+          if: ${{ github.event.inputs.DEPLOY_TO_GITHUB_PAGES == 'true' }}
+          run: |
+            # We use the Github Rest api to get information regarding pages for the Github Repository and store it into a temporary file named "pages_response".
+            set +e
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/${{ github.repository_owner }}/$(basename ${{ github.repository }})/pages > pages_response
+
+            # We make sure Github Pages has been enabled for this repository.
+            if [ "$?" -ne 0 ]; then
+              echo "::error title=Potential pages configuration error.::Please make sure you have enabled Github pages for the ${{ github.repository }} repository. If already enabled then Github pages might be down"
+              echo "terminate=true" >> $GITHUB_ENV
+            fi
+            set -e
+
+            # We make sure the Github pages build & deployment source is set to "workflow" (Github Actions). Instead of a "legacy" (branch).
+            if [[ "$(jq --compact-output --raw-output .build_type pages_response)" != "workflow" ]]; then
+                echo "Undefined behaviour, Make sure the Github Pages source is correctly configured in the Github Pages settings."
+                echo "::error title=Pages configuration error.::Please make sure you have correctly picked \"Github Actions\" as the build and deployment source for the Github Pages."
+                echo "terminate=true" >> $GITHUB_ENV
+            fi
+            rm pages_response
+
+        - name: Terminate run if error occurred.
+          run: |
+            if [[ $terminate == "true" ]]; then
+              gh run cancel ${{ github.run_id }}
+              gh run watch ${{ github.run_id }}
+            fi
+
   build:
+    needs: guard_clause # Dependency
     runs-on: ubuntu-latest # Image to run the worker on.
 
     env:
@@ -43,23 +98,10 @@ jobs:
 
     permissions: # Permissions to grant the GITHUB_TOKEN.
       contents: write  # Required permission to make a github release.
-      actions: 'write' # Required for the Dockerfile path guard clause.
 
     steps:
       # Checks-out our repository under $GITHUB_WORKSPACE, so our job can access it
       - uses: actions/checkout@v3
-      # Guard clause that cancels the workflow in case of an invalid DOCKERFILE_PATH. 
-      # The main reason for choosing this workaround for aborting the workflow is the fact that it does not display the workflow as successful, which can set false expectations.
-      - name: DOCKERFILE_PATH guard clause
-        shell: bash 
-        run: |
-          if [ ! -f ${{ github.event.inputs.DOCKERFILE_PATH }} ]; then
-              echo "::error title=Invalid Dockerfile path::No file found at ${{ github.event.inputs.DOCKERFILE_PATH }}"
-              gh run cancel ${{ github.run_id }}
-              gh run watch ${{ github.run_id }}
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }} # As required by the GitHub-CLI
 
       # Setting the IMAGE_NAME variable in GITHUB_ENV to <Dockerfile name>_<date>_<run_id>.ext2.
       - name: Generate the image_name.


### PR DESCRIPTION
# Changes: 

- Moved the guard-clause to its own separate job.
- Build workflow now depends on the guard-clause.
- Workflow now errors, logs and terminates when a user has: 
A.) wrongly configured Github pages for their repository or 
B.) Github pages is not reachable by the API for whatever reason and exits non-zero.
- Removed Github token `action:write` permission from the `build` workflow. As this was only in there for the guard clause and is no no longer required.

Should make the problem from issue: #69 more clear to users.