### PR TITLE
Network: Fix Undefined ExitNode in map.peers

### DIFF
--- a/src/lib/network.js
+++ b/src/lib/network.js
@@ -39,7 +39,7 @@ function netmapUpdateCb(map)
 {
 	networkData.currentIp = map.self.addresses[0];
 	var exitNodeFound = false;
-	for(var i=0;map.peers.length;i++)
+	for(var i=0; i < map.peers.length;i++)
 	{
 		if(map.peers[i].exitNode)
 		{


### PR DESCRIPTION
The issue was that the peers.map is a 0 indexed array. Meaning that the index went too far. this has been fixed