### PR TITLE
Don't wait for the network login promise

### DIFF
--- a/src/lib/WebVM.svelte
+++ b/src/lib/WebVM.svelte
@@ -335,7 +335,7 @@
 	async function handleConnect()
 	{
 		const w = window.open("login.html", "_blank");
-		await cx.networkLogin();
+		cx.networkLogin();
 		w.location.href = await startLogin();
 	}
 	async function handleReset()


### PR DESCRIPTION
It was always unnecessary, and now the promise resolves when the network is actually usable, which is after startLogin resolves. The previous await would now cause a "deadlock".

Depends on https://github.com/leaningtech/cheerpx/pull/334 and https://github.com/leaningtech/cheerpos/pull/48