### PR TITLE
Readme dev image updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ WebVM is powered by the **CheerpX** virtualization engine, which provides:
 
 - [Networking](#networking)
 - [Development & Customization](#development--customization)
-  - [Local Serving & Image Configuration](#local-serving--image-configuration)
   - [Deploy to GitHub Pages](#deploy-to-github-pages)
+  - [Local Serving & Image Configuration](#local-serving--image-configuration)
 - [Claude AI Integration](#claude-ai-integration)
 - [Community & Support](#community--support)
 - [Learn More](#learn-more)
@@ -97,6 +97,23 @@ https://yourdomain.com/#controlUrl=<your-headscale-url>
 
 ## Development & Customization
 
+### Deploy to GitHub Pages
+
+This is a simple, beginner-friendly workflow. For local hosting and customization, see below [Local Serving & Image Configuration](#local-serving--image-configuration).
+
+Fork the WebVM repository to deploy your own version to GitHub Pages:
+
+<img src="/assets/fork_deploy_instructions.gif" alt="deploy_instructions_gif" width="90%">
+
+1. **Fork the repository**
+2. **Enable GitHub Pages** in Settings → Pages using "GitHub Actions" as source
+3. **Run the `Deploy` workflow** from Actions
+4. After completion, open the URL shown under the `deploy_to_github_pages` job
+
+<img src="/assets/result.png" width="70%">
+
+The same `Deploy` workflow also builds custom `.ext2` disk images from a Dockerfile. You can point it at `dockerfiles/debian_mini` or another Dockerfile, then either publish the result as a GitHub Release asset or deploy the Pages build from your fork.
+
 ### Local Serving & Image Configuration
 
 #### 1. Clone the repository
@@ -140,21 +157,6 @@ nginx -p . -c nginx.conf
 ```
 
 Then open `http://127.0.0.1:8081` and enjoy your local WebVM!
-
-### Deploy to GitHub Pages
-
-Fork the WebVM repository to deploy your own version to GitHub Pages:
-
-<img src="/assets/fork_deploy_instructions.gif" alt="deploy_instructions_gif" width="90%">
-
-1. **Fork the repository**
-2. **Enable GitHub Pages** in Settings → Pages using "GitHub Actions" as source
-3. **Run the `Deploy` workflow** from Actions
-4. After completion, open the URL shown under the `deploy_to_github_pages` job
-
-<img src="/assets/result.png" width="70%">
-
-The same `Deploy` workflow also builds custom `.ext2` disk images from a Dockerfile. You can point it at `dockerfiles/debian_mini` or another Dockerfile, then either publish the result as a GitHub Release asset or deploy the Pages build from your fork.
 
 For the full Alpine desktop environment, see [leaningtech/alpine-image](https://github.com/leaningtech/alpine-image).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ WebVM supports **Tailscale** integration. So your browser VM can reach your priv
 4.  Click "Connect" when prompted
 
 WebVM now has access to all machines in your Tailscale network!
- 
+
 ### Internet Usage Tips
 
 > [!TIP]
@@ -97,7 +97,8 @@ https://yourdomain.com/#controlUrl=<your-headscale-url>
 
 ## Development & Customization
 
-> [!NOTE] Users have root privileges by default. `sudo` is not installed though this can easily be added to the Dockerfile if needed.
+> [!NOTE]
+> Users have root privileges by default. `sudo` is not installed though this can easily be added to the Dockerfile if needed.
 
 ### Deploy to GitHub Pages
 
@@ -108,7 +109,7 @@ Fork the WebVM repository to deploy your own version to GitHub Pages:
 <img src="/assets/fork_deploy_instructions.gif" alt="deploy_instructions_gif" width="90%">
 
 1. **Fork the repository**
-2. **Enable GitHub Pages** *via forked repository* in Settings → Pages using "GitHub Actions" as source
+2. **Enable GitHub Pages** _via forked repository_ in Settings → Pages using "GitHub Actions" as source
 3. **Run the `Deploy` workflow** from Actions
 4. After completion, open the URL shown under the `deploy_to_github_pages` job
 
@@ -116,7 +117,8 @@ Fork the WebVM repository to deploy your own version to GitHub Pages:
 
 The same `Deploy` workflow also builds custom `.ext2` disk images from a Dockerfile. You can point it at `dockerfiles/debian_mini` or another Dockerfile, then either publish the result as a GitHub Release asset or deploy the Pages build from your fork.
 
-> [!NOTE] `dockerfiles/debian_large` is too large of an image for GitHub pages.
+> [!NOTE]
+> `dockerfiles/debian_large` is too large of an image for GitHub pages.
 
 ### Local Serving & Image Configuration
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ https://yourdomain.com/#controlUrl=<your-headscale-url>
 
 ## Development & Customization
 
+> [!NOTE] Users have root privileges by default. `sudo` is not installed though this can easily be added to the Dockerfile if needed.
+
 ### Deploy to GitHub Pages
 
 This is a simple, beginner-friendly workflow. For local hosting and customization, see below [Local Serving & Image Configuration](#local-serving--image-configuration).
@@ -106,13 +108,15 @@ Fork the WebVM repository to deploy your own version to GitHub Pages:
 <img src="/assets/fork_deploy_instructions.gif" alt="deploy_instructions_gif" width="90%">
 
 1. **Fork the repository**
-2. **Enable GitHub Pages** in Settings → Pages using "GitHub Actions" as source
+2. **Enable GitHub Pages** *via forked repository* in Settings → Pages using "GitHub Actions" as source
 3. **Run the `Deploy` workflow** from Actions
 4. After completion, open the URL shown under the `deploy_to_github_pages` job
 
 <img src="/assets/result.png" width="70%">
 
 The same `Deploy` workflow also builds custom `.ext2` disk images from a Dockerfile. You can point it at `dockerfiles/debian_mini` or another Dockerfile, then either publish the result as a GitHub Release asset or deploy the Pages build from your fork.
+
+> [!NOTE] `dockerfiles/debian_large` is too large of an image for GitHub pages.
 
 ### Local Serving & Image Configuration
 

--- a/dockerfiles/debian_large
+++ b/dockerfiles/debian_large
@@ -1,4 +1,4 @@
-FROM --platform=i386 i386/debian:bookworm
+FROM --platform=linux/386 i386/debian:bookworm
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get -y upgrade && \

--- a/dockerfiles/debian_mini
+++ b/dockerfiles/debian_mini
@@ -1,4 +1,4 @@
-FROM --platform=i386 i386/debian:bookworm
+FROM --platform=linux/386 i386/debian:bookworm
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get clean && apt-get update && apt-get -y upgrade
 RUN apt-get -y install apt-utils gcc \


### PR DESCRIPTION
README.md
- reordered to put github pages workflow first, clarifying this to be the primary workflow
- noted that dockerfiles/debian_large image is too large for github pages
- noted that sudo is not installed, users have root by default

Dockerfiles
- updated the base image fixing github pages issues, also tested this locally

Other
- added 'custom-disk-images' directory with .gitkeep since this is part of the tutorial for local hosting but directory wasn't in the repo 

Still need to:
- merge Alphine repo into this one
- bundle tips into connection tips section