### PR TITLE
Validate Tailscale login URL scheme

### DIFF
--- a/src/lib/WebVM.svelte
+++ b/src/lib/WebVM.svelte
@@ -336,7 +336,15 @@
 	{
 		const w = window.open("login.html", "_blank");
 		cx.networkLogin();
-		w.location.href = await startLogin();
+		try
+		{
+			w.location.href = await startLogin();
+		}
+		catch(e)
+		{
+			w.close();
+			console.warn(e);
+		}
 	}
 	async function handleReset()
 	{

--- a/src/lib/network.js
+++ b/src/lib/network.js
@@ -12,12 +12,17 @@ if(browser)
 let dashboardUrl = controlUrl ? null : "https://login.tailscale.com/admin/machines";
 let resolveLogin = null;
 let rejectLogin = null;
-let loginPromise = new Promise((f,r) => {
-	resolveLogin = f;
-	rejectLogin = r;
-});
+let loginPromise = null;
 let connectionState = writable("DISCONNECTED");
 let exitNode = writable(false);
+
+function resetLoginPromise()
+{
+	loginPromise = new Promise((f,r) => {
+		resolveLogin = f;
+		rejectLogin = r;
+	});
+}
 
 function validateLoginUrl(url)
 {
@@ -37,6 +42,7 @@ function loginUrlCb(url)
 	{
 		connectionState.set("LOGINFAILED");
 		rejectLogin(e);
+		resetLoginPromise();
 		return;
 	}
 	connectionState.set("LOGINREADY");
@@ -180,3 +186,5 @@ export function updateButtonData(state, handleConnect) {
 export const networkInterface = { authKey: authKey, controlUrl: controlUrl, loginUrlCb: loginUrlCb, stateUpdateCb: stateUpdateCb, netmapUpdateCb: netmapUpdateCb };
 
 export const networkData = { currentIp: null, connectionState: connectionState, exitNode: exitNode, loginUrl: null, dashboardUrl: dashboardUrl }
+
+resetLoginPromise();

--- a/src/lib/network.js
+++ b/src/lib/network.js
@@ -11,14 +11,34 @@ if(browser)
 }
 let dashboardUrl = controlUrl ? null : "https://login.tailscale.com/admin/machines";
 let resolveLogin = null;
+let rejectLogin = null;
 let loginPromise = new Promise((f,r) => {
 	resolveLogin = f;
+	rejectLogin = r;
 });
 let connectionState = writable("DISCONNECTED");
 let exitNode = writable(false);
 
+function validateLoginUrl(url)
+{
+	const parsedUrl = new URL(url);
+	if(parsedUrl.protocol != "https:" && parsedUrl.protocol != "http:")
+		throw new Error("Invalid Tailscale login URL scheme");
+	return parsedUrl.href;
+}
+
 function loginUrlCb(url)
 {
+	try
+	{
+		url = validateLoginUrl(url);
+	}
+	catch(e)
+	{
+		connectionState.set("LOGINFAILED");
+		rejectLogin(e);
+		return;
+	}
 	connectionState.set("LOGINREADY");
 	resolveLogin(url);
 }
@@ -115,6 +135,15 @@ export function updateButtonData(state, handleConnect) {
 				isClickable: true,
 				clickHandler: null,
 				clickUrl: networkData.loginUrl,
+				buttonTooltip: null,
+				rightClickHandler: null
+			};
+		case "LOGINFAILED":
+			return {
+				buttonText: "Invalid login URL",
+				isClickable: false,
+				clickHandler: null,
+				clickUrl: null,
 				buttonTooltip: null,
 				rightClickHandler: null
 			};


### PR DESCRIPTION
This fixes the custom Tailscale/Headscale login flow so returned auth URLs must be normal http(s) URLs before WebVM navigates the login popup to them.

A malicious custom control server should not be able to return a scriptable URL such as javascript: and have it execute in the WebVM origin.

validation happens when the login URL is received, before it reaches either the popup navigation or the sidebar link. If validation fails, the login popup is closed and the UI shows an invalid login URL state.

I validated this locally:
- javascript: login URL is rejected
- popup closes and does not expose localStorage
- normal https login URL still works for me
- npm run build succeeds