### PR TITLE
reverted dockerfiles to debian buster for stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ pnpm-lock.yaml
 build/
 custom-disk-images/*
 !custom-disk-images/.gitkeep
+nginx_access.log
+nginx_error.log
+nginx_main_error.log

--- a/config_public_terminal.js
+++ b/config_public_terminal.js
@@ -1,5 +1,5 @@
 // The root OS image location, change to local filepath if serving locally
-export const diskImageUrl = "wss://disks.webvm.io/debian_large_20230522_5044875331_2.ext2";
+export const diskImageUrl = "wss://disks.webvm.io/buster_image_large_26_05_2026.ext2";
 // The root filesystem backend type use "cloud" for serving remotely or "bytes" for serving locally
 export const diskImageType = "cloud";
 // Print an introduction message about the technology

--- a/dockerfiles/debian_large
+++ b/dockerfiles/debian_large
@@ -1,10 +1,16 @@
-FROM --platform=linux/386 i386/debian:bookworm
+FROM --platform=linux/386 docker.io/i386/debian:buster
 ARG DEBIAN_FRONTEND=noninteractive
+
+# Point APT to the archived mirrors (Buster is EOL)
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian buster main contrib non-free" \
+  > /etc/apt/sources.list && \
+	echo "deb [trusted=yes] http://archive.debian.org/debian-security buster/updates main" \
+	>> /etc/apt/sources.list
 
 RUN apt-get update && apt-get -y upgrade && \
 	apt-get install -y apt-utils beef bsdgames bsdmainutils ca-certificates \
 	cowsay cpio cron curl dmidecode dmsetup g++ gcc gdbm-l10n git  \
-	hexedit  ifupdown init logrotate lsb-base lshw lua5.4 luajit lynx make \
+	hexedit  ifupdown init logrotate lsb-base lshw lua5.3 luajit lynx make \
 	nano netbase nodejs openssl procps python3 python3-cryptography \
 	python3-jinja2 python3-numpy python3-pandas python3-pip python3-scipy \
 	python3-six python3-yaml readline-common rsyslog ruby sensible-utils \
@@ -15,5 +21,9 @@ RUN apt-get update && apt-get -y upgrade && \
 RUN useradd -m user && echo "user:password" | chpasswd
 COPY --chown=user:user ./examples /home/user/examples
 RUN chmod -R +x  /home/user/examples/lua
+# We set WORKDIR, as this gets extracted by Webvm to be used as the cwd. This is optional.
+WORKDIR /home/user/
+# We set env, as this gets extracted by Webvm. This is optional.
+ENV HOME="/home/user" TERM="xterm" USER="user" SHELL="/bin/bash" EDITOR="vim" LANG="en_US.UTF-8" LC_ALL="C"
 RUN echo 'root:password' | chpasswd
 CMD [ "/bin/bash" ]

--- a/dockerfiles/debian_mini
+++ b/dockerfiles/debian_mini
@@ -1,11 +1,18 @@
-FROM --platform=linux/386 i386/debian:bookworm
+FROM --platform=linux/386 docker.io/i386/debian:buster
 ARG DEBIAN_FRONTEND=noninteractive
+
+# Point APT to the archived mirrors (Buster is EOL)
+RUN echo "deb [trusted=yes] http://archive.debian.org/debian buster main contrib non-free" \
+  > /etc/apt/sources.list && \
+	echo "deb [trusted=yes] http://archive.debian.org/debian-security buster/updates main" \
+	>> /etc/apt/sources.list
+
 RUN apt-get clean && apt-get update && apt-get -y upgrade
 RUN apt-get -y install apt-utils gcc \
 	python3 vim unzip ruby nodejs \
 	fakeroot dbus base whiptail hexedit \
 	patch wamerican ucf manpages \
-	file luajit make lua5.4 dialog curl \
+	file luajit make lua5.3 dialog curl \
 	less cowsay netcat-openbsd
 RUN useradd -m user && echo "user:password" | chpasswd
 COPY --chown=user:user ./examples /home/user/examples


### PR DESCRIPTION
reverted distro back to debian buster for assured 
stability. 

changes made:
-pointed sources to archived debian buster repos
- reverted lua to 5.3 for compability with debian buster
- specified docker.io as registry for buildah
- set workdir in large image for consistency with mini image
- pointed to newly build image with prior mentioned changes